### PR TITLE
One possible fix for launch concurrency issues

### DIFF
--- a/reset.sh
+++ b/reset.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+DATABASE_NAME=smart-ui
+DATABASE_USER=smart
+
+echo Please enter the smart database password when asked...
+
+dropdb -U $DATABASE_USER $DATABASE_NAME
+createdb -U $DATABASE_USER -O $DATABASE_USER --encoding='utf8' $DATABASE_NAME
+
+python manage.py syncdb

--- a/settings.py.default
+++ b/settings.py.default
@@ -77,7 +77,6 @@ TEMPLATE_DIRS = (
 CONCURRENT_THREADING = False
 INSTALLED_APPS = (
     'django_concurrent_test_server',
-    'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',

--- a/settings.py.default
+++ b/settings.py.default
@@ -6,6 +6,11 @@ SMART_API_SERVER_BASE = '{{api_server_base_url}}'
 CONSUMER_KEY='{{chrome_consumer}}'
 CONSUMER_SECRET='{{chrome_secret}}'
 
+DATABASE_ENGINE = 'postgresql_psycopg2'           # 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
+DATABASE_NAME = 'smart-ui'             # Or path to database file if using sqlite3.
+DATABASE_USER = 'smart'             # Not used with sqlite3.
+DATABASE_PASSWORD = 'smart'         # Not used with sqlite3.
+
 
 HIDE_GET_MORE_APPS = False
 

--- a/ui/models.py
+++ b/ui/models.py
@@ -1,0 +1,16 @@
+"""
+SMART Connect token store
+"""
+from django.db import models
+from django.conf import settings
+import urllib, datetime
+
+class SmartConnectToken(models.Model):
+  """
+  SMART Connect Token + Secret, scoped to a django session
+  """
+
+  session_key = models.CharField(max_length=40)
+  smart_connect_token = models.CharField(max_length=40, primary_key=True)
+  smart_connect_secret = models.CharField(max_length=40)
+


### PR DESCRIPTION
django sessions can't (easily) be used for a function like `launch_app` which may execute multiple times in rapid succession and each instance attempts to add to the the django session.  While storing tokens should be "append-only", django sessions glom together a whole bundle of relevant state in a single db blob (a pickled, base64-encoded python object).

So: one approach is to split this out into a small local model for storing tokens.

Issues:
- Do we want to store this state in the ui-server (not a huge departure from tokens already stored in the session, but we may want to move this over to smart-server nonetheless)
- ~~Still need a `reset.sh` or equivalent (called by `smart_manager.py`) to clear and `python manage.py syncdb` on server rest.~~ https://github.com/chb/smart_server/pull/13
