### PR TITLE
Added support for apps with querystring params in their index URLs

### DIFF
--- a/ui/static/smart_common/resources/smart-api-container.js
+++ b/ui/static/smart_common/resources/smart-api-container.js
@@ -134,8 +134,9 @@ window.SMART_CONNECT_HOST = function() {
 		var base_url =  app_instance.manifest.base_url;
 		launch_url = launch_url.replace("{base_url}", base_url);
 
-		launch_url += "?oauth_header="+
-		    encodeURIComponent(app_instance.credentials.oauth_header);
+		querystring_sep = launch_url.indexOf('?') !== -1 ? '&' : '?';
+		launch_url += querystring_sep + "oauth_header=" +
+			encodeURIComponent(app_instance.credentials.oauth_header);
 
 		app_instance.origin = __SMART_extract_origin(launch_url);
 		app_instance.iframe.src = launch_url;


### PR DESCRIPTION
Turns out that this support is basically a one-liner: no need to parse the whole query string and add the OAuth header to it.
